### PR TITLE
add charRegExp to options for sentenceSplitter's argument

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,9 @@ textlint --rule no-doubled-joshi README.md
             // 例外を許可するかどうか
             "strict": false,
             // 助詞のうち「も」「や」は複数回の出現を許す
-            "allow": ["も","や"]
+            "allow": ["も","や"],
+            // 文区切り文字の正規表現
+            "charRegExp": /[。\?\!？！]/
         }
     }
 }
@@ -68,6 +70,8 @@ textlint --rule no-doubled-joshi README.md
     - 下記参照。例外としているものもエラーとするかどうか
 - `allow`(default: []) :複数回の出現を許す助詞
     - 並立の助詞など、複数回出現しても無視する助詞を指定します。
+- `charRegExp`(default: /[。\?\!？！]/) : 文区切り文字の正規表現
+    - ピリオドや全角ピリオドを句点とする文章を評価するときは明示的に指定します。
 
 > 私**は**彼**は**好き
 

--- a/src/no-doubled-joshi.js
+++ b/src/no-doubled-joshi.js
@@ -1,13 +1,116 @@
 // LICENSE : MIT
 "use strict";
-import {RuleHelper} from "textlint-rule-helper";
-import {getTokenizer} from "kuromojin";
-import {split as splitSentences, Syntax as SentenceSyntax} from "sentence-splitter";
-import StringSource from "textlint-util-to-string";
-import {
-    is助詞Token, is読点Token,
-    createKeyFromKey, restoreToSurfaceFromKey
-} from "./token-utils";
+
+Object.defineProperty(exports, "__esModule", {
+    value: true
+});
+
+exports.default = function (context) {
+    var options = arguments.length > 1 && arguments[1] !== undefined ? arguments[1] : {};
+
+    var helper = new _textlintRuleHelper.RuleHelper(context);
+    // 最低間隔値
+    var minInterval = options.min_interval || defaultOptions.min_interval;
+    var isStrict = options.strict || defaultOptions.strict;
+    var allow = options.allow || defaultOptions.allow;
+    var charRegExp = options.charRegExp || defaultOptions.charRegExp;
+    var Syntax = context.Syntax,
+        report = context.report,
+        getSource = context.getSource,
+        RuleError = context.RuleError;
+
+    return _defineProperty({}, Syntax.Paragraph, function (node) {
+        if (helper.isChildNode(node, [Syntax.Link, Syntax.Image, Syntax.BlockQuote, Syntax.Emphasis])) {
+            return;
+        }
+        var source = new _textlintUtilToString2.default(node);
+        var text = source.toString();
+        var isSentenceNode = function isSentenceNode(node) {
+            return node.type === _sentenceSplitter.Syntax.Sentence;
+        };
+        var sentences = (0, _sentenceSplitter.split)(text, {
+            charRegExp: charRegExp
+        }).filter(isSentenceNode);
+        return (0, _kuromojin.getTokenizer)().then(function (tokenizer) {
+            var checkSentence = function checkSentence(sentence) {
+                var tokens = tokenizer.tokenizeForSentence(sentence.raw);
+                var countableTokens = tokens.filter(function (token) {
+                    if (isStrict) {
+                        return (0, _tokenUtils.is助詞Token)(token);
+                    }
+                    // デフォルトでは、"、"を間隔値の距離としてカウントする
+                    // "、" があると助詞同士の距離が開くようにすることで、並列的な"、"の使い方を許容する目的
+                    // https://github.com/azu/textlint-rule-no-doubled-joshi/issues/2
+                    return (0, _tokenUtils.is助詞Token)(token) || (0, _tokenUtils.is読点Token)(token);
+                });
+                var joshiTokenSurfaceKeyMap = createSurfaceKeyMap(countableTokens);
+                /*
+                 # Data Structure
+                  joshiTokens = [tokenA, tokenB, tokenC, tokenD, tokenE, tokenF]
+                 joshiTokenSurfaceKeyMap = {
+                 "は:助詞.係助詞": [tokenA, tokenC, tokenE],
+                 "で:助詞.係助詞": [tokenB, tokenD, tokenF]
+                 }
+                 */
+                Object.keys(joshiTokenSurfaceKeyMap).forEach(function (key) {
+                    var tokens = joshiTokenSurfaceKeyMap[key];
+                    var joshiName = (0, _tokenUtils.restoreToSurfaceFromKey)(key);
+                    // check allow
+                    if (allow.indexOf(joshiName) >= 0) {
+                        return;
+                    }
+                    // strict mode ではない時例外を除去する
+                    if (!isStrict) {
+                        if (matchExceptionRule(tokens)) {
+                            return;
+                        }
+                    }
+                    if (tokens.length <= 1) {
+                        return; // no duplicated token
+                    }
+                    // if found differenceIndex less than
+                    // tokes are sorted ascending order
+                    tokens.reduce(function (prev, current) {
+                        var startPosition = countableTokens.indexOf(prev);
+                        var otherPosition = countableTokens.indexOf(current);
+                        // 助詞token同士の距離が設定値以下ならエラーを報告する
+                        var differenceIndex = otherPosition - startPosition;
+                        if (differenceIndex <= minInterval) {
+                            var originalIndex = source.originalIndexFromPosition({
+                                line: sentence.loc.start.line,
+                                column: sentence.loc.start.column + (current.word_position - 1)
+                            });
+                            // padding positionを計算する
+                            var padding = {
+                                index: originalIndex
+                            };
+                            report(node, new RuleError("\u4E00\u6587\u306B\u4E8C\u56DE\u4EE5\u4E0A\u5229\u7528\u3055\u308C\u3066\u3044\u308B\u52A9\u8A5E \"" + joshiName + "\" \u304C\u307F\u3064\u304B\u308A\u307E\u3057\u305F\u3002", padding));
+                        }
+                        return current;
+                    });
+                });
+            };
+            sentences.forEach(checkSentence);
+        });
+    });
+};
+
+var _textlintRuleHelper = require("textlint-rule-helper");
+
+var _kuromojin = require("kuromojin");
+
+var _sentenceSplitter = require("sentence-splitter");
+
+var _textlintUtilToString = require("textlint-util-to-string");
+
+var _textlintUtilToString2 = _interopRequireDefault(_textlintUtilToString);
+
+var _tokenUtils = require("./token-utils");
+
+function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
+
+function _defineProperty(obj, key, value) { if (key in obj) { Object.defineProperty(obj, key, { value: value, enumerable: true, configurable: true, writable: true }); } else { obj[key] = value; } return obj; }
+
 /**
  * Create token map object
  * {
@@ -19,9 +122,9 @@ import {
  */
 function createSurfaceKeyMap(tokens) {
     // 助詞のみを対象とする
-    return tokens.filter(is助詞Token).reduce((keyMap, token) => {
+    return tokens.filter(_tokenUtils.is助詞Token).reduce(function (keyMap, token) {
         // "は:助詞.係助詞" : [token]
-        const tokenKey = createKeyFromKey(token);
+        var tokenKey = (0, _tokenUtils.createKeyFromKey)(token);
         if (!keyMap[tokenKey]) {
             keyMap[tokenKey] = [];
         }
@@ -30,7 +133,7 @@ function createSurfaceKeyMap(tokens) {
     }, {});
 }
 function matchExceptionRule(tokens) {
-    let token = tokens[0];
+    var token = tokens[0];
     // "の" の重なりは例外
     if (token.pos_detail_1 === "連体化") {
         return true;
@@ -48,10 +151,11 @@ function matchExceptionRule(tokens) {
 /*
  default options
  */
-const defaultOptions = {
+var defaultOptions = {
     min_interval: 1,
     strict: false,
-    allow: []
+    allow: [],
+    charRegExp: /[。\?\!？！]/
 };
 
 /*
@@ -62,88 +166,6 @@ const defaultOptions = {
 
  TODO: need abstraction
  */
-export default function(context, options = {}) {
-    const helper = new RuleHelper(context);
-    // 最低間隔値
-    const minInterval = options.min_interval || defaultOptions.min_interval;
-    const isStrict = options.strict || defaultOptions.strict;
-    const allow = options.allow || defaultOptions.allow;
-    const {Syntax, report, getSource, RuleError} = context;
-    return {
-        [Syntax.Paragraph](node){
-            if (helper.isChildNode(node, [Syntax.Link, Syntax.Image, Syntax.BlockQuote, Syntax.Emphasis])) {
-                return;
-            }
-            const source = new StringSource(node);
-            const text = source.toString();
-            const isSentenceNode = node => {
-                return node.type === SentenceSyntax.Sentence;
-            };
-            let sentences = splitSentences(text, {
-                charRegExp: /[。\?\!？！]/
-            }).filter(isSentenceNode);
-            return getTokenizer().then(tokenizer => {
-                const checkSentence = (sentence) => {
-                    let tokens = tokenizer.tokenizeForSentence(sentence.raw);
-                    let countableTokens = tokens.filter(token => {
-                        if (isStrict) {
-                            return is助詞Token(token);
-                        }
-                        // デフォルトでは、"、"を間隔値の距離としてカウントする
-                        // "、" があると助詞同士の距離が開くようにすることで、並列的な"、"の使い方を許容する目的
-                        // https://github.com/azu/textlint-rule-no-doubled-joshi/issues/2
-                        return is助詞Token(token) || is読点Token(token);
-                    });
-                    let joshiTokenSurfaceKeyMap = createSurfaceKeyMap(countableTokens);
-                    /*
-                     # Data Structure
-
-                     joshiTokens = [tokenA, tokenB, tokenC, tokenD, tokenE, tokenF]
-                     joshiTokenSurfaceKeyMap = {
-                     "は:助詞.係助詞": [tokenA, tokenC, tokenE],
-                     "で:助詞.係助詞": [tokenB, tokenD, tokenF]
-                     }
-                     */
-                    Object.keys(joshiTokenSurfaceKeyMap).forEach(key => {
-                        const tokens = joshiTokenSurfaceKeyMap[key];
-                        const joshiName = restoreToSurfaceFromKey(key);
-                        // check allow
-                        if (allow.indexOf(joshiName) >= 0) {
-                            return;
-                        }
-                        // strict mode ではない時例外を除去する
-                        if (!isStrict) {
-                            if (matchExceptionRule(tokens)) {
-                                return;
-                            }
-                        }
-                        if (tokens.length <= 1) {
-                            return;// no duplicated token
-                        }
-                        // if found differenceIndex less than
-                        // tokes are sorted ascending order
-                        tokens.reduce((prev, current) => {
-                            const startPosition = countableTokens.indexOf(prev);
-                            const otherPosition = countableTokens.indexOf(current);
-                            // 助詞token同士の距離が設定値以下ならエラーを報告する
-                            const differenceIndex = otherPosition - startPosition;
-                            if (differenceIndex <= minInterval) {
-                                const originalIndex = source.originalIndexFromPosition({
-                                    line: sentence.loc.start.line,
-                                    column: sentence.loc.start.column + (current.word_position - 1)
-                                });
-                                // padding positionを計算する
-                                const padding = {
-                                    index: originalIndex
-                                };
-                                report(node, new RuleError(`一文に二回以上利用されている助詞 "${joshiName}" がみつかりました。`, padding));
-                            }
-                            return current;
-                        });
-                    });
-                };
-                sentences.forEach(checkSentence);
-            });
-        }
-    }
-};
+;
+module.exports = exports["default"];
+//# sourceMappingURL=no-doubled-joshi.js.map

--- a/test/no-doubled-joshi-test.js
+++ b/test/no-doubled-joshi-test.js
@@ -22,6 +22,11 @@ tester.run("no-double-joshi", rule, {
         {
             text: "太字も強調も同じように無視されます。",
             options: {allow: ["も"]}
+        },
+        // 全角ピリオドを文区切り文字に含める
+        {
+            text: "画面に表示されます．それ以外には表示されません．",
+            options: {charRegExp: /[。．\?\!？！]/}
         }
     ],
     invalid: [


### PR DESCRIPTION
文区切り文字が全角ピリオドの文章を lint するとき、意図しないところでエラーになるのに気づきました。
no-doubled-joshiのオプションで制御できるようにしたいです。
