### PR TITLE
fix: prevent token mutation

### DIFF
--- a/src/no-doubled-joshi.ts
+++ b/src/no-doubled-joshi.ts
@@ -275,7 +275,7 @@ const report: TextlintRuleModule<Options> = function (context, options = {}) {
                     }
                     // strict mode ではない時例外を除去する
                     if (!isStrict) {
-                        if (matchExceptionRule(joshiTokenSurfaceTokens, tokens)) {
+                        if (matchExceptionRule(joshiTokenSurfaceTokens, concatedJoshiTokens)) {
                             return;
                         }
                     }
@@ -292,11 +292,11 @@ const report: TextlintRuleModule<Options> = function (context, options = {}) {
                         if (differenceIndex <= minInterval) {
                             // 連続する助詞を集める
                             const startWord = toTextWithPrevWord(prev, {
-                                tokens: tokens,
+                                tokens: concatedJoshiTokens,
                                 sentence: sentence
                             });
                             const endWord = toTextWithPrevWord(current, {
-                                tokens: tokens,
+                                tokens: concatedJoshiTokens,
                                 sentence: sentence
                             });
                             // padding positionを計算する

--- a/src/token-utils.ts
+++ b/src/token-utils.ts
@@ -48,7 +48,7 @@ const concatToken = (aToken: KuromojiToken, bToken: KuromojiToken) => {
  * @param {Array} tokens
  * @returns {Array}
  */
-export const concatJoishiTokens = (tokens: KuromojiToken[]) => {
+export const concatJoishiTokens = (tokens: readonly KuromojiToken[]) => {
     const newTokens: KuromojiToken[] = [];
     tokens.forEach((token) => {
         const prevToken = newTokens[newTokens.length - 1];

--- a/src/token-utils.ts
+++ b/src/token-utils.ts
@@ -36,10 +36,12 @@ export const create読点Matcher = (commaCharacters: string[]) => {
  * @returns {Object}
  */
 const concatToken = (aToken: KuromojiToken, bToken: KuromojiToken) => {
-    aToken.surface_form += bToken.surface_form;
-    aToken.pos += bToken.pos;
-    aToken.pos_detail_1 += bToken.surface_form;
-    return aToken;
+    return {
+        ...aToken,
+        surface_form: aToken.surface_form + bToken.surface_form,
+        pos: aToken.pos + bToken.pos,
+        pos_detail_1: aToken.pos_detail_1 + bToken.surface_form
+    };
 };
 /**
  * 助詞+助詞 というように連続しているtokenを結合し直したtokenの配列を返す


### PR DESCRIPTION
## 概要
`concatToken` が引数として渡された元トークンを変更せずに処理するよう修正しました。

## 背景
`kuromojin` は同一テキストに対してトークンをキャッシュします。そのため、リントを複数回実行すると、キャッシュされたトークンが書き換えられ、同一の入力に対して実行するたびにエラー範囲やメッセージが変化してしまう不具合がありました。
[こちら](https://github.com/yuta0709/no-doubled-joshi-bug-repro)が不具合の再現のリポジトリです。

## 変更点
### token-utils.ts
- `concatToken` で引数のオブジェクトを書き換えず、新しいオブジェクトを返すようにしました。

### no-doubled-joshi.ts
- `matchExceptionRule` と `toTextWithPrevWord` に渡す配列を `concatedJoshiTokens` に変更
  - トークンが書き換えられる前提で`indexOf`が使われている場所があったため、`concatToken`が新しいオブジェクトを返しても正しく動作するように変更しました。


## 補足
↓のように、モジュールとしてtextlintを使用した際に起こる不具合の修正です。
https://textlint.org/docs/use-as-modules#overview